### PR TITLE
Replaced heartbeat word command by client word

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,24 +77,24 @@ Execute the script `ìnstall.ps1` in Windows, admin is required to make the inst
     hostbeat     -h | --help                               show help
     hostbeat     -v | --version                            show program version
 
-    hostbeat     heartbeat   config     --set-url          sets a new url in the configuration file
-    hostbeat     heartbeat   config     --set-token        sets a new token in the configuration file
-    hostbeat     heartbeat   config     --set-interval     sets a new interval in the configuration file
+    hostbeat     client   config     --set-url          sets a new url in the configuration file
+    hostbeat     client   config     --set-token        sets a new token in the configuration file
+    hostbeat     client   config     --set-interval     sets a new interval in the configuration file
 
-    hostbeat     heartbeat   daemon                        send heartbeats as a daemon using the configuration file
-    hostbeat     heartbeat   daemon     --use-url          send heartbeats as a daemon using custom url, overrides file value
-    hostbeat     heartbeat   daemon     --use-token        send heartbeats as a daemon using custom token, overrides file value
-    hostbeat     heartbeat   daemon     --use-interval     send heartbeats as a daemon using custom interval, overrides file value
+    hostbeat     client   daemon                        send heartbeats as a daemon using the configuration file
+    hostbeat     client   daemon     --use-url          send heartbeats as a daemon using custom url, overrides file value
+    hostbeat     client   daemon     --use-token        send heartbeats as a daemon using custom token, overrides file value
+    hostbeat     client   daemon     --use-interval     send heartbeats as a daemon using custom interval, overrides file value
 
-    hostbeat     heartbeat   send                          send one heartbeat using data from file
-    hostbeat     heartbeat   send       --use-url          send heartbeat to custom url, overrides file value
-    hostbeat     heartbeat   send       --use-token        send heartbeat with custom token, overrides file value
+    hostbeat     client   send                          send one heartbeat using data from file
+    hostbeat     client   send       --use-url          send heartbeat to custom url, overrides file value
+    hostbeat     client   send       --use-token        send heartbeat with custom token, overrides file value
     ```
 - Usage
     ```zsh
-    hostbeat heartbeat config --set-token mocktoken --set-interval 1.0
-    hostbeat heartbeat daemon
-    hostbeat heartbeat send --use-token anothermocktoken
+    hostbeat client config --set-token mocktoken --set-interval 1.0
+    hostbeat client daemon
+    hostbeat client send --use-token anothermocktoken
     ```
 
 ## 🏭 Building release

--- a/hostbeat-help.txt
+++ b/hostbeat-help.txt
@@ -1,15 +1,15 @@
 hostbeat     -h | --help                               show help
 hostbeat     -v | --version                            show program version
 
-hostbeat     heartbeat   config     --set-url          sets a new url in the configuration file
-hostbeat     heartbeat   config     --set-token        sets a new token in the configuration file
-hostbeat     heartbeat   config     --set-interval     sets a new interval in the configuration file
+hostbeat     client   config     --set-url          sets a new url in the configuration file
+hostbeat     client   config     --set-token        sets a new token in the configuration file
+hostbeat     client   config     --set-interval     sets a new interval in the configuration file
 
-hostbeat     heartbeat   daemon                        send heartbeats as a daemon using the configuration file
-hostbeat     heartbeat   daemon     --use-url          send heartbeats as a daemon using custom url, overrides file value
-hostbeat     heartbeat   daemon     --use-token        send heartbeats as a daemon using custom token, overrides file value
-hostbeat     heartbeat   daemon     --use-interval     send heartbeats as a daemon using custom interval, overrides file value
+hostbeat     client   daemon                        send heartbeats as a daemon using the configuration file
+hostbeat     client   daemon     --use-url          send heartbeats as a daemon using custom url, overrides file value
+hostbeat     client   daemon     --use-token        send heartbeats as a daemon using custom token, overrides file value
+hostbeat     client   daemon     --use-interval     send heartbeats as a daemon using custom interval, overrides file value
 
-hostbeat     heartbeat   send                          send one heartbeat using data from file
-hostbeat     heartbeat   send       --use-url          send heartbeat to custom url, overrides file value
-hostbeat     heartbeat   send       --use-token        send heartbeat with custom token, overrides file value
+hostbeat     client   send                          send one heartbeat using data from file
+hostbeat     client   send       --use-url          send heartbeat to custom url, overrides file value
+hostbeat     client   send       --use-token        send heartbeat with custom token, overrides file value

--- a/src/libs/utils.rs
+++ b/src/libs/utils.rs
@@ -6,22 +6,22 @@ pub mod cli {
         hostbeat     -h | --help                               show help
         hostbeat     -v | --version                            show program version
 
-        hostbeat     heartbeat   config                        gets current stored configuration
-        hostbeat     heartbeat   config     --get-token        gets current stored token
-        hostbeat     heartbeat   config     --get-url          gets current stored url
-        hostbeat     heartbeat   config     --get-interval     gets current stored interval
-        hostbeat     heartbeat   config     --set-url          sets a new url in the configuration file
-        hostbeat     heartbeat   config     --set-token        sets a new token in the configuration file
-        hostbeat     heartbeat   config     --set-interval     sets a new token in the configuration file
+        hostbeat     client   config                        gets current stored configuration
+        hostbeat     client   config     --get-token        gets current stored token
+        hostbeat     client   config     --get-url          gets current stored url
+        hostbeat     client   config     --get-interval     gets current stored interval
+        hostbeat     client   config     --set-url          sets a new url in the configuration file
+        hostbeat     client   config     --set-token        sets a new token in the configuration file
+        hostbeat     client   config     --set-interval     sets a new token in the configuration file
 
-        hostbeat     heartbeat   daemon                        send heartbeats as a daemon using the configuration file
-        hostbeat     heartbeat   daemon     --use-url          send heartbeats as a daemon using custom url, overrides file value
-        hostbeat     heartbeat   daemon     --use-token        send heartbeats as a daemon using custom token, overrides file value
-        hostbeat     heartbeat   daemon     --use-interval     send heartbeats as a daemon using custom interval, overrides file value
+        hostbeat     client   daemon                        send heartbeats as a daemon using the configuration file
+        hostbeat     client   daemon     --use-url          send heartbeats as a daemon using custom url, overrides file value
+        hostbeat     client   daemon     --use-token        send heartbeats as a daemon using custom token, overrides file value
+        hostbeat     client   daemon     --use-interval     send heartbeats as a daemon using custom interval, overrides file value
 
-        hostbeat     heartbeat   send                          send one heartbeat using data from file
-        hostbeat     heartbeat   send     --use-url            send heartbeat to custom url, overrides file value
-        hostbeat     heartbeat   send     --use-token          send heartbeat with custom token, overrides file value
+        hostbeat     client   send                          send one heartbeat using data from file
+        hostbeat     client   send     --use-url            send heartbeat to custom url, overrides file value
+        hostbeat     client   send     --use-token          send heartbeat with custom token, overrides file value
         ");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ fn main() {
         exit(exitcode::DATAERR, false, "> Invalid parameter, please read help");
     }
 
-    if second_arg == "heartbeat" {
+    if second_arg == "client" {
 
         if args.len() <= 2 {
             exit(exitcode::USAGE, true, "");
@@ -167,7 +167,7 @@ fn main() {
                 };
             }
 
-            exit(exitcode::DATAERR, false, "> Command for heartbeat not found, please read help");
+            exit(exitcode::DATAERR, false, "> Command for client not found, please read help");
         }
 
         exit(exitcode::DATAERR, false, "> Heartbeat command does not have parameters, please read help");


### PR DESCRIPTION
- Replaced to make it easir to understand for users. This will help to distinguish the different features we can have in the command line tool between the app and the client.